### PR TITLE
Remove next-line.

### DIFF
--- a/gcal.el
+++ b/gcal.el
@@ -77,21 +77,21 @@
   "Parse HTTP response in buffer."
   (with-current-buffer buffer
     ;; Response Line (ex: HTTP/1.1 200 OK)
-    (beginning-of-buffer)
+    (goto-char (point-min))
     (if (looking-at "^HTTP/[^ ]+ \\([0-9]+\\) ?\\(.*\\)$")
         (let ((status (string-to-number (match-string 1)))
               (message (match-string 2))
               (headers)
               (body))
-          (next-line)
+          (forward-line)
           ;; Header Lines
           (while (not (eolp))
             (if (looking-at "^\\([^:]+\\): \\(.*\\)$")
                 (push (cons (match-string 1) (match-string 2)) headers))
-            (next-line))
+            (forward-line))
 
           ;; Body
-          (next-line)
+          (forward-line)
           (setq body (buffer-substring (point) (point-max)))
 
           ;; Result


### PR DESCRIPTION
next-line is interactive-only function.
It sometimes made json-parse error, so use forward-line and begining-of-line.